### PR TITLE
Upgraded to 2.9, with code taken from script I wrote to do just this.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,50 @@
-Admin Tool - Reset My Moodle
-======================
+# Admin Tool - Reset My Moodle
 
-Information
------------
 
-This admin tool allow reset preferences in My Moodle All Users mymoodle except main admin.
+## Information
+
+This admin tool allows you to reset all 'My Moodle' pages for all users, except the main administrator, with a single click.
+
 It's useful to developers and main administrators.
 
-Version  
--------
-Moodle 2.7+ and 2.6+
 
-TO INSTALL:
+## Version  
 
-Git way
-- To install it using git, type this command in the root of your Moodle install:
+Moodle 2.9+.
+
+
+## Installation
+
+### Using Git
+
+To install it using git, type this command in the root of your Moodle install:
+
 ```
 git clone git@github.com:cescobedo/moodle-tool_resetmymoodle.git admin/tool/resetmymoodle
 ```
 
+### Downloading a Zip file
 
-Download way
 - Download the zip from <https://github.com/cescobedo/moodle-tool_resetmymoodle/archive/master.zip>
-- Unzip it into  admin/tool/ folder in your Moodle,
-- Rename the new folder "moodle-tool_resetmymoodle-master" to "resetmymoodle"
+- Unzip it into admin/tool/ folder in your Moodle,
+- Rename the new folder from "moodle-tool_resetmymoodle-master" to "resetmymoodle"
 - Enjoy!!!
 
-FUTURE SCOPE:
-- Refactor to 2.7+ to use new reset functions in my/lib.php
-- Use new system Logs.
-- Select specifics users.
 
-Author
-------
+## Future Scope
+
+- Use new system Logs.
+- Select or exclude specifics users.
+
+
+## Author
+
 Carlos Escobedo
 - <http://www.twitter.com/carlosagile>
 - <https://coderwall.com/carlosagile>
 
+Edits to upgrade the code for Moodle 2.9:
+
+Paul Vaughan
+- <http://www.twitter.com/sdcmoodle>
+- <https://github.com/sdc> 

--- a/index.php
+++ b/index.php
@@ -24,6 +24,8 @@
 
 require('../../../config.php');
 require_once($CFG->libdir.'/adminlib.php');
+require_once( '../../../my/lib.php' );
+
 global $DB;
 
 admin_externalpage_setup('toolresetmymoodle');
@@ -53,20 +55,14 @@ echo $OUTPUT->box_start();
 $siteadmins = explode(',', $CFG->siteadmins);
 $myadminid = $siteadmins[0];
 
-$sql = "SELECT u.*, mp.id as myid
-        FROM {my_pages} mp,
-        {user} u
-        where u.id = mp.userid
-        and mp.userid is not null
-        and u.id <> ?";
-if ($myusers = $DB->get_records_sql($sql, array($myadminid))) {
+if ( $users = $DB->get_records( 'user' ) ) {
     $countusers = 0;
-    foreach ($myusers as $myuser) {
-        // Delete mypage user.
-        $DB->delete_records('my_pages', array('userid' => $myuser->id));
-        // Delete blocks user.
-        $DB->delete_records('block_instances', array('subpagepattern' => $myuser->myid));
-        $countusers = $countusers + 1;
+    foreach ($users as $user) {
+        if ($user->id != $myadminid) {
+            // Call internal Moodle function to reset the user.
+            my_reset_page( $user->id );
+            $countusers++;
+        }
     }
     echo $OUTPUT->notification(get_string('resetok', 'tool_resetmymoodle', $countusers), 'notifysuccess');
 } else {

--- a/lang/en/tool_resetmymoodle.php
+++ b/lang/en/tool_resetmymoodle.php
@@ -24,7 +24,6 @@
 
 $string['pluginname'] = 'Reset MyMoodle';
 $string['pageheader'] = 'Reset My Moodle';
-$string['resetok'] = 'Reset operation: {$a} Users has been reset.';
-$string['nopages'] = 'Reset operation: NO My Moodles Users.';
-$string['warning'] = 'WARNING: This tool allow you reset all MyMoodle preferences
-in all users except Main ADMIN User.';
+$string['resetok'] = 'Reset operation: {$a} users have been reset.';
+$string['nopages'] = 'Reset operation: NO My Moodle users were reset.';
+$string['warning'] = 'WARNING: This tool will reset all MyMoodle preferences in all users except the main Admin user.';

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2014051600;
-$plugin->requires  = 2013111800;
+$plugin->version   = 2015100200;
+$plugin->requires  = 2015051100;
 $plugin->component = 'tool_resetmymoodle';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = '1.0';
+$plugin->release = '1.1';


### PR DESCRIPTION
We needed to do a whole-Moodle 'My Moodle' reset recently and I wrote a quick script to do it.  When I saw this plugin, I simply added in the function to reset 'My Moodle' from the existing script.  Very little else has changed.  Is probably compatible with 2.8 also, but I don't have one to hand to test.
